### PR TITLE
🧹 `Journal`: `Entry#summary` fits better than `Entry#description`

### DIFF
--- a/db/migrate/20240129014151_journal_add_description_to_entry.rb
+++ b/db/migrate/20240129014151_journal_add_description_to_entry.rb
@@ -1,5 +1,5 @@
 class JournalAddDescriptionToEntry < ActiveRecord::Migration[7.1]
   def change
-    add_column :journal_entries, :description, :text
+    add_column :journal_entries, :summary, :text
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -116,7 +116,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_29_014151) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "keywords", array: true
-    t.text "description"
+    t.text "summary"
     t.index ["journal_id"], name: "index_journal_entries_on_journal_id"
   end
 


### PR DESCRIPTION
- https://github.com/zinc-collective/convene-journal/pull/8
- https://github.com/zinc-collective/convene-journal/issues/10

When I started on this, I started with [changes to the data layer], because that's where my brain tends to naturally start.

But when I wrote the [system test], I realized it was more of an [`Entries#summary`].

So I am renaming from `Entries#description` to `Entries#summary`.

Thank you for coming to my TED Talk.

[`Entries#summary`]: https://github.com/zinc-collective/convene-journal/pull/9
[system test]: https://github.com/zinc-collective/convene-journal/pull/9
[changes to the data layer]: https://github.com/zinc-collective/convene-journal/pull/8