### PR TITLE
🧹 `Journal`: Annnnd this is what I get without CI

### DIFF
--- a/app/furniture/journal/entry.rb
+++ b/app/furniture/journal/entry.rb
@@ -33,8 +33,8 @@ class Journal
 
     scope :matching_keywords, ->(keywords) { where("keywords::text[] && ARRAY[?]::text[]", keywords) }
 
-    DESCRIPTION_MAX_LENGTH = 300
-    validates :description, length: {maximum: DESCRIPTION_MAX_LENGTH, allow_blank: true}
+    SUMMARY_MAX_LENGTH = 300
+    validates :summary, length: {maximum: SUMMARY_MAX_LENGTH, allow_blank: true}
 
     def migrate_to(journal:, keywords: [])
       new_body = keywords.present? ? body + "\n##{keywords.join(" #")}" : body

--- a/spec/furniture/journal/entry_spec.rb
+++ b/spec/furniture/journal/entry_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Journal::Entry, type: :model do
     end
   end
 
-  describe "#description" do
-    it { is_expected.to validate_length_of(:description).is_at_most(300).allow_blank }
+  describe "#summary" do
+    it { is_expected.to validate_length_of(:summary).is_at_most(300).allow_blank }
   end
 
   describe "#save" do


### PR DESCRIPTION
While working on
https://github.com/zinc-collective/convene-journal/pull/11, I completely forgot to run the tests locally. Embaressing, right? But I've grown overly used to codebases where running tests takes minutes-not-seconds; and there's not an easy way to "scope" the tests run to just the code that matters.

Also I'm hacking while high, sue me!

Anyway, people forget things... For reasons. And this time I forgot this, which exposed a hole in the safety-net in my weird multi-repo experiment.

So I patched the hole in the bottom of the sea...
sea: https://github.com/zinc-collective/convene-journal/pull/12

Which uncovered a log in the hole in the bottom of the sea: https://github.com/zinc-collective/convene/pull/2160

So now I'm finishing the refactor and putting the frog on the log in the hole of the bottom of the sea, so that I can feed a gnat to the frog on the log in the hole of the bottom of the sea and implement the form fields to capture the `Entry#summary`